### PR TITLE
Rng bug fix + CLI configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ image = "0.24.3"
 num = "0.4.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"
+clap = { version = "4.0.32", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.3.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,8 @@ fn main() {
             RCNLayer::Pool2D(Pooling::Max),
         ],
         &[30],
-        "images\\mnist_png\\train",
-        "images\\mnist_png\\valid",
+        "images/mnist_png/training",
+        "images/mnist_png/testing",
     );
-
-    model.train(10, 100, 3_f64, 500).unwrap();
+    model.train(10, 100, 3_f64, 1000, 800).unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,50 @@
+use clap::Parser;
 use mercer_research::{
     utils::kernel::{Padding, Pooling},
     RCNLayer, RCN,
 };
 
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Number of classes
+    #[arg(short, long, default_value_t = 10)]
+    num_classes: usize,
+
+    /// Training directory
+    #[arg(long, default_value_t = String::from("images/mnist_png/training"))]
+    training_path: String,
+
+    /// Testing/validation directory
+    #[arg(long, default_value_t = String::from("images/mnist_png/testing"))]
+    testing_path: String,
+
+    /// Number of items to train on per class
+    #[arg(long, default_value_t = 500)]
+    training_class_size: usize,
+
+    /// Number of items to test on per class
+    #[arg(long, default_value_t = 500)]
+    testing_class_size: usize,
+
+    /// Learning rate (eta value)
+    #[arg(short, long, default_value_t = 3.0)]
+    learning_rate: f64,
+
+    /// Number of training cycles before update
+    #[arg(short, long, default_value_t = 10)]
+    batches: usize,
+
+    /// Number of passes through the entire training set
+    #[arg(short, long, default_value_t = 30)]
+    epochs: usize,
+}
+
 fn main() {
+    let args = Args::parse();
+
     let mut model = RCN::new(
-        10,
+        args.num_classes,
         &[
             RCNLayer::Convolve2D(Padding::Same),
             RCNLayer::Pool2D(Pooling::Max),
@@ -13,8 +52,16 @@ fn main() {
             RCNLayer::Pool2D(Pooling::Max),
         ],
         &[30],
-        "images/mnist_png/training",
-        "images/mnist_png/testing",
+        &args.training_path,
+        &args.testing_path,
     );
-    model.train(10, 100, 3_f64, 1000, 800).unwrap();
+    model
+        .train(
+            args.batches,
+            args.epochs,
+            args.learning_rate,
+            args.training_class_size,
+            args.testing_class_size,
+        )
+        .unwrap();
 }


### PR DESCRIPTION
Use `clap` to configure application easier. Makes easier to port to other systems that might not have the same file structure or want different hyperparameters.